### PR TITLE
Fix user patch failure

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.scim/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim/SCIMProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim/SCIMProvisioningConnector.java
@@ -541,10 +541,10 @@ public class SCIMProvisioningConnector extends AbstractOutboundProvisioningConne
         for (Iterator<Map.Entry<ClaimMapping, List<String>>> iterator = attributes.entrySet().iterator();
              iterator.hasNext(); ) {
             Map.Entry<ClaimMapping, List<String>> entry = iterator.next();
-            if (SCIMConstants.META_CREATED_URI.equals(entry.getKey().getLocalClaim().getClaimUri()) ||
-                    SCIMConstants.ID_URI.equals(entry.getKey().getLocalClaim().getClaimUri()) ||
-                    SCIMConstants.META_LOCATION_URI.equals(entry.getKey().getLocalClaim().getClaimUri()) ||
-                    SCIMConstants.META_LAST_MODIFIED_URI.equals(entry.getKey().getLocalClaim().getClaimUri())) {
+            if (SCIMConstants.META_CREATED_URI.equals(entry.getKey().getRemoteClaim().getClaimUri()) ||
+                    SCIMConstants.ID_URI.equals(entry.getKey().getRemoteClaim().getClaimUri()) ||
+                    SCIMConstants.META_LOCATION_URI.equals(entry.getKey().getRemoteClaim().getClaimUri()) ||
+                    SCIMConstants.META_LAST_MODIFIED_URI.equals(entry.getKey().getRemoteClaim().getClaimUri())) {
                 iterator.remove();
             }
         }


### PR DESCRIPTION
Resolves 2nd point of https://github.com/wso2/product-is/issues/6311 and https://github.com/wso2/product-is/issues/6300


SCIM1.1 outbound provisioning user PACH operation was failing with the following log
```
ERROR {org.wso2.carbon.identity.scim.common.impl.ProvisioningClient} - An array of "attributes" needs to be present in "meta" of the SCIM request
```
The reason for this was, in the SCIM1.1 user PATCH operation, the `meta` attribute is used to denote the attributes which need to be removed from the original resource according to [1]. But a bug in the meta attribute filtering logic of the user object has lead to send the last modified time attribute in the `meta` attribute of SCIM1.1 PATCH operation. This PR resolves that issue.

Previously
```
"meta":{"lastModified":"2020-12-11T20:08:39"}
```

Now
```
"meta":{"attributes": []}
```


[1] https://tools.ietf.org/html/draft-scim-api-01#section-3.3.2