### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <url>https://github.com/wso2-extensions/identity-outbound-provisioning-scim.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-outbound-provisioning-scim.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-outbound-provisioning-scim.git</connection>
-        <tag>v5.3.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>
@@ -198,12 +198,12 @@
 
     <properties>
         <!--Carbon framework version-->
-        <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
-        <identity.framework.version>5.15.7</identity.framework.version>
-        <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
+        <carbon.identity.framework.import.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.import.version.range>
+        <identity.framework.version>6.0.0</identity.framework.version>
+        <carbon.identity.framework.import.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.import.version.range>
 
-        <identity.inbound.provisioning.scim.version>5.1.3</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim.import.version.range>[5.0.0, 6.0.0)</identity.inbound.provisioning.scim.import.version.range>
+        <identity.inbound.provisioning.scim.version>6.0.0</identity.inbound.provisioning.scim.version>
+        <identity.inbound.provisioning.scim.import.version.range>[6.0.0, 7.0.0)</identity.inbound.provisioning.scim.import.version.range>
         <identity.outbound.provisioning.scim.export.version>${project.version}</identity.outbound.provisioning.scim.export.version>
 
         <!-- Carbon kernel version -->


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16